### PR TITLE
add open attribute for details

### DIFF
--- a/src/types/yomitan/termbank.ts
+++ b/src/types/yomitan/termbank.ts
@@ -116,6 +116,7 @@ type StructuredContentNode =
       data?: StructuredContentData;
       style?: StructuredContentStyle;
       title?: string;
+      open?: boolean;
       lang?: string;
     }
   | {


### PR DESCRIPTION
Prevents a type warning when adding `open` to a `details` element.

Relates to https://github.com/yomidevs/yomitan/pull/1740.