### PR TITLE
Add methods to set source and target languages in DictionaryIndex

### DIFF
--- a/src/builders/dictionaryIndex.ts
+++ b/src/builders/dictionaryIndex.ts
@@ -62,6 +62,14 @@ export class DictionaryIndex {
     this.index.frequencyMode = mode;
     return this;
   }
+  setSourceLanguage(sourceLanguage: DictionaryIndexType['sourceLanguage']) {
+    this.index.sourceLanguage = sourceLanguage;
+    return this;
+  }
+  setTargetLanguage(targetLanguage: DictionaryIndexType['targetLanguage']) {
+    this.index.targetLanguage = targetLanguage;
+    return this;
+  }
   build() {
     if (!this.index.title) throw new Error('Title is required');
     if (!this.index.revision) throw new Error('Revision is required');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dictionary builders now support fluent configuration for source and target languages using chainable setter methods. This enhancement enables developers to set up dictionary language pairs more efficiently and intuitively. The fluent API improves code readability and allows configuration steps to flow naturally within standard builder workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->